### PR TITLE
Fix nvim indentation issues.

### DIFF
--- a/.vim/lua/config/nvim-treesitter.lua
+++ b/.vim/lua/config/nvim-treesitter.lua
@@ -83,6 +83,6 @@ require'nvim-treesitter.configs'.setup {
   },
 
   indent = {
-    enable = true,
+    enable = false,
   }
 }

--- a/.vim/plugins/config/ale.vim
+++ b/.vim/plugins/config/ale.vim
@@ -1,12 +1,11 @@
 " Heavily stolen from https://blog.ffff.lt/posts/typescript-and-ale/
-" let node_fixers = ['prettier', 'eslint']
-" let node_fixers = ['eslint']
+let node_fixers = ['prettier', 'eslint']
 
-" let g:ale_fixers = {
-" \  'javascript':node_fixers,
-" \  'typescript': node_fixers,
-" \  'ruby': ['rubocop'],
-" \}
+let g:ale_fixers = {
+\  'javascript': node_fixers,
+\  'typescript': node_fixers,
+\  'ruby': ['rubocop'],
+\}
 
 " let g:ale_fix_on_save = 1
 
@@ -37,7 +36,3 @@
 
 " let g:ale_virtualtext_cursor = 1
 " let g:ale_virtualtext_prefix = '🔥 '
-
-let g:ale_fixers = {
-\  'ruby': ['rubocop'],
-\}


### PR DESCRIPTION
Tree-sitter's indent feature suddenly started causing block/autoindentation to fail. I don't know why it only started recently, but disabling the feature fixes the issue.


Also, YOLO my ECMA script autofixers. Life is too short to type `eslint` all the time.